### PR TITLE
FIX: Fix creation of translations with targetLanguageKeys defined

### DIFF
--- a/Classes/Service/GeneratorService.php
+++ b/Classes/Service/GeneratorService.php
@@ -411,7 +411,7 @@ class GeneratorService
             $parsedXliffArray = $xliffParser->getParsedData($sourceLanguageFile);
             foreach ($targetLanguageKeys as $targetLanguageKey) {
                 $contextVariables['targetLanguageKey'] = $targetLanguageKey;
-                $contextVariables['translationUnits'] = $parsedXliffArray['translationUnits'];
+                $contextVariables['translationUnits'] = $parsedXliffArray[0]['translationUnits'];
 
                 $templatePathAndFilename = 'resource://Neos.Kickstarter/Private/Generator/Translations/TargetLanguageTemplate.xlf.tmpl';
                 $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);


### PR DESCRIPTION
If you try to create translations with the parameter `--target-language-keys` defined, you will get an error that `translationUnits` is not defined in `Neos\Kickstarter\Service\GeneratorService`. This is, because `Neos\Flow\I18n\Xliff\V12\XliffParser::getParsedData` will return an array (for each `<file>`-Entry in the Xliff-File, typically only one entry). So we need to use the first item of that data to get the translationUnits from it.

The PR is made against the 4.3 branch, as this is the latest still supported version.